### PR TITLE
fix: improve error handling for invalid JSON and JQ command inputs

### DIFF
--- a/jq_playground.py
+++ b/jq_playground.py
@@ -66,13 +66,21 @@ class JQPlayground(QWidget):
         jq_command = self.jq_input.toPlainText()
 
         if not json_text.strip():
-            QMessageBox.warning(
-                self, "Aviso", "Você precisa fornecer um JSON válido.")
+            alert = QMessageBox()
+            alert.setIcon(QMessageBox.Icon.Critical)
+            alert.setText("JSON inválido")
+            alert.setInformativeText("Você precisa fornecer um JSON válido.")
+            alert.setWindowTitle("Aviso")
+            alert.exec()
             return
 
         if not jq_command.strip():
-            QMessageBox.warning(
-                self, "Aviso", "Você precisa fornecer um comando jq.")
+            alert = QMessageBox()
+            alert.setIcon(QMessageBox.Icon.Critical)
+            alert.setText("Comando JQ inválido")
+            alert.setInformativeText("Você precisa fornecer um comando jq válido.")
+            alert.setWindowTitle("Aviso")
+            alert.exec()
             return
 
         try:


### PR DESCRIPTION
This pull request updates the `run_jq` method in `jq_playground.py` to enhance the user experience by improving the error message display. The changes replace the previous `QMessageBox.warning` calls with a more detailed and customizable `QMessageBox` configuration.

### Improvements to error message display:

* [`jq_playground.py`](diffhunk://#diff-3e3d51309f3eaa45649ca63456b026dddef85add0e0e7032bd01b3812b3a53afL69-R83): Replaced `QMessageBox.warning` with a more detailed `QMessageBox` setup that includes an icon, a main text, and additional informative text for better clarity when displaying error messages for invalid JSON input or invalid jq commands.